### PR TITLE
Added new name to build tag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vuesic
-[![Build Status](https://travis-ci.org/vuesic/vuesic.svg?branch=master)](https://travis-ci.org/vuesic/vuesic)
+[![Build Status](https://travis-ci.org/vusic/vusic.svg?branch=master)](https://travis-ci.org/vusic/vusic)
 > A DAW for the 21st century!
 
 ## Envrionment Setup


### PR DESCRIPTION
# Description
Added the new build tag to README.md. This wasn't taken care of when we changed the name so now the link is 404ing
